### PR TITLE
Add ability to show name/path of current window

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ set sessionoptions+=tabpages,globals
 With this option you can customize the look of tabs. Below all the available items:
 
 - `%f`: the name of the first buffer open in the tab
+- `%F`: the name of the buffer open in the current window of the tab
 - `%a`: the path relative to `$HOME` of the first buffer open in the tab
+- `%A`: the path relative to `$HOME` of the buffer open in the current window of the tab
 - `%n`: the tab number, but only on the active tab
 - `%N`: the tab number on each tab
 - `%w`: the number of windows opened into the tab, but only on the active tab

--- a/doc/taboo.txt
+++ b/doc/taboo.txt
@@ -72,7 +72,9 @@ With this option you can customize the look of tabs. Below all the
 available items:
 
     `%f` -> the name of the first buffer open in the tab
+    `%F` -> the name of the buffer open in the current window of the tab
     `%a` -> the path relative to `$HOME` of the first buffer open in the tab
+    `%A` -> the path relative to `$HOME` of the buffer open in the current window of the tab
     `%n` -> the tab number, but only on the active tab
     `%N` -> the tab number on each tab
     `%w` -> the number of windows opened into the tab, but only on the active tab

--- a/plugin/taboo.vim
+++ b/plugin/taboo.vim
@@ -105,7 +105,9 @@ endfu
 fu s:expand(tabnr, fmt)
     let out = a:fmt
     let out = substitute(out, '\C%f', s:bufname(a:tabnr), "")
+    let out = substitute(out, '\C%F', s:bufnameCurrentWin(a:tabnr), "")
     let out = substitute(out, '\C%a', s:bufpath(a:tabnr), "")
+    let out = substitute(out, '\C%A', s:bufpathCurrentWin(a:tabnr), "")
     let out = substitute(out, '\C%n', s:tabnum(a:tabnr, 0), "")
     let out = substitute(out, '\C%N', s:tabnum(a:tabnr, 1), "")
     let out = substitute(out, '\C%w', s:wincount(a:tabnr, 0), "")
@@ -198,9 +200,31 @@ fu s:bufname(tabnr)
     return g:taboo_unnamed_tab_label
 endfu
 
+fu s:bufnameCurrentWin(tabnr)
+    let buffers = tabpagebuflist(a:tabnr)
+    let win_idx = tabpagewinnr(a:tabnr)
+    let buf = buffers[win_idx - 1]
+    let bname = bufname(buf > -1 ? buf : buffers[0])
+    if !empty(bname)
+        return s:basename(bname)
+    endif
+    return g:taboo_unnamed_tab_label
+endfu
+
 fu s:bufpath(tabnr)
     let buffers = tabpagebuflist(a:tabnr)
     let buf = s:first_normal_buffer(buffers)
+    let bname = bufname(buf > -1 ? buf : buffers[0])
+    if !empty(bname)
+        return s:fullpath(bname, 1)
+    endif
+    return g:taboo_unnamed_tab_label
+endfu
+
+fu s:bufpathCurrentWin(tabnr)
+    let buffers = tabpagebuflist(a:tabnr)
+    let win_idx = tabpagewinnr(a:tabnr)
+    let buf = buffers[win_idx - 1]
     let bname = bufname(buf > -1 ? buf : buffers[0])
     if !empty(bname)
         return s:fullpath(bname, 1)


### PR DESCRIPTION
This adds `%A` and `%P` tab format items. These are similar to `%a` and
`%p` except that they show the name/path of the buffer in the current
window of the tab.