### PR TITLE
Don't format tab modified flag if not in control of tabline

### DIFF
--- a/plugin/taboo.vim
+++ b/plugin/taboo.vim
@@ -176,12 +176,14 @@ endfu
 fu s:modflag(tabnr)
     for buf in tabpagebuflist(a:tabnr)
         if getbufvar(buf, "&mod")
-            if a:tabnr == tabpagenr()
-               return "%#TabModifiedSelected#"
+            if !g:taboo_tabline
+                return g:taboo_modified_tab_flag
+            elseif a:tabnr == tabpagenr()
+                return "%#TabModifiedSelected#"
                         \. g:taboo_modified_tab_flag
                         \. "%#TabLineSel#"
             else
-               return "%#TabModified#"
+                return "%#TabModified#"
                         \. g:taboo_modified_tab_flag
                         \. "%#TabLine#"
             endif


### PR DESCRIPTION
Turn off formatting of the tab modified flag if the `g:gaboo_tabline` option is turned off. This avoids interfering with the formatting generated by the airline-tabline extension.

Fixes gcmt/taboo.vim#22